### PR TITLE
fix: excluded client generator from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -20,6 +20,7 @@ dist
 /.projenrc.js
 tsconfig.tsbuildinfo
 /.eslintrc.json
+src/client-generator/**
 /.gitattributes
 /.projenrc.ts
 /projenrc

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -76,6 +76,10 @@
       "type": "build"
     },
     {
+      "name": "swagger-typescript-api",
+      "type": "build"
+    },
+    {
       "name": "ts-jest",
       "type": "build"
     },
@@ -97,10 +101,6 @@
     },
     {
       "name": "projen",
-      "type": "runtime"
-    },
-    {
-      "name": "swagger-typescript-api",
       "type": "runtime"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -231,13 +231,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@gemeentenijmegen/projen-project-type,@types/jest,@types/jsonwebtoken,@types/node,axios-mock-adapter,dotenv,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,ts-jest,ts-node,typescript,axios,jsonwebtoken,swagger-typescript-api"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@gemeentenijmegen/projen-project-type,@types/jest,@types/jsonwebtoken,@types/node,axios-mock-adapter,dotenv,eslint-import-resolver-typescript,eslint-plugin-import,jest,projen,swagger-typescript-api,ts-jest,ts-node,typescript,axios,jsonwebtoken"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @gemeentenijmegen/projen-project-type @stylistic/eslint-plugin @types/jest @types/jsonwebtoken @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser axios-mock-adapter commit-and-tag-version constructs dotenv eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit projen ts-jest ts-node typescript axios jsonwebtoken swagger-typescript-api"
+          "exec": "yarn upgrade @gemeentenijmegen/projen-project-type @stylistic/eslint-plugin @types/jest @types/jsonwebtoken @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser axios-mock-adapter commit-and-tag-version constructs dotenv eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit projen swagger-typescript-api ts-jest ts-node typescript axios jsonwebtoken"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -8,13 +8,13 @@ const project = new GemeenteNijmegenTsPackage({
   description: 'Package that generates zgw clients and helpers.',
   repository: 'https://github.com/GemeenteNijmegen/modules-zgw-client',
   deps: [
-    'swagger-typescript-api', // Generates client, always has to be mocked in tests - module not commonjs
     'ts-node', // To run class in github workflow
     'axios', // Clients generated with axios, fetch does not generate a proper class
     'jsonwebtoken',
     'projen', // Needed in deps to make client-updates-custom-workflow
   ],
   devDeps: [
+    'swagger-typescript-api', // Generates client, always has to be mocked in tests - module not commonjs
     '@gemeentenijmegen/projen-project-type',
     'dotenv', // Needed to use .env vars
     '@types/jsonwebtoken',
@@ -43,7 +43,7 @@ const project = new GemeenteNijmegenTsPackage({
   gitignore: ['**/output/', '**/testmockforjest-generated-client/'],
   projenrcTs: true,
 });
-
+project.addPackageIgnore('src/client-generator/**');
 // Custom workflow to update zgw clients based on vng gemma-zaken github
 // Only used in this project - otherwise it would be located in modules projen
 addZgwClientsUpdateWorkflow(project);

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "jest": "^29.7.0",
     "jest-junit": "^16",
     "projen": "^0.92.10",
+    "swagger-typescript-api": "^13.2.1",
     "ts-jest": "^29.3.4",
     "ts-node": "^10.9.2",
     "typescript": "^5.8.3"
@@ -51,7 +52,6 @@
     "axios": "^1.9.0",
     "jsonwebtoken": "^9.0.2",
     "projen": "^0.92.10",
-    "swagger-typescript-api": "^13.2.1",
     "ts-node": "^10.9.2"
   },
   "main": "lib/index.js",

--- a/src/catalogi-zaaktypes/ZaakTypeOverview.ts
+++ b/src/catalogi-zaaktypes/ZaakTypeOverview.ts
@@ -51,15 +51,15 @@ export interface ZaakTypeOverview {
   apiOmgeving?: string;
 
 
-  statusTypen:{ url: string; kenmerk?: string; omschrijving?: string; default?: boolean}[];
-  resultaatTypen: { url: string; kenmerk?: string; omschrijving?: string; default?: boolean}[];
-  eigenschappen: { url: string; kenmerk?: string; naam?: string; default?: boolean}[];
-  informatieObjectTypen?: { url: string; kenmerk?: string; omschrijving?: string;default?: boolean}[];
-  rolTypen: { url: string; kenmerk?: string; omschrijving?: string; default?: boolean}[];
+  statusTypen: { url: string; kenmerk?: string; omschrijving?: string; default?: boolean }[];
+  resultaatTypen: { url: string; kenmerk?: string; omschrijving?: string; default?: boolean }[];
+  eigenschappen: { url: string; kenmerk?: string; naam?: string; default?: boolean }[];
+  informatieObjectTypen?: { url: string; kenmerk?: string; omschrijving?: string;default?: boolean }[];
+  rolTypen: { url: string; kenmerk?: string; omschrijving?: string; default?: boolean }[];
   /**
      * De laatste versie van het gehele zaaktype object indien gewenst
      * Op deze manier kan het gehele origineel snel bekeken worden
      */
-  completeZaakType? : catalogi.ZaakType;
+  completeZaakType?: catalogi.ZaakType;
 }
 

--- a/src/client-generator/ClientGenerator.ts
+++ b/src/client-generator/ClientGenerator.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'path';
+/* eslint-disable import/no-extraneous-dependencies */
 import { generateApi } from 'swagger-typescript-api';
 import { partialInputHook } from './partialInputHook';
 import { rolFixHook } from './rolFixHook';


### PR DESCRIPTION
Clientgenerator is niet nodig om de generated clients te kunnen gebruiken, puur om het te genereren nodig.
Dependency swagger-typescript-api daarom ook uit published package